### PR TITLE
Fix rate limiting in plugin list renderer

### DIFF
--- a/.github/workflows/render.yaml
+++ b/.github/workflows/render.yaml
@@ -15,10 +15,10 @@ jobs:
     permissions:
       contents: write # for git push
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Setup dependencies
         run: python -m pip install -r scripts/requirements.txt
       - name: Rerender README

--- a/scripts/plugin_list.py
+++ b/scripts/plugin_list.py
@@ -1,29 +1,70 @@
 import os
 import sys
+import time
 import tomllib
 
 import github
+from github import GithubException
+
+
+RETRY_WAIT = 60
+MAX_RETRIES = 5
 
 
 def search_github():
-    gh = github.Github(os.environ.get("GITHUB_TOKEN"))
+    gh = github.Github(os.environ.get("GITHUB_TOKEN"), per_page=30)
     results = gh.search_code('"[project.entry-points.conda]" language:TOML')
     if results.totalCount:
         return results
     raise RuntimeError("Did not find any results")
 
 
+def _fetch_with_retry(fn, label=""):
+    """Call *fn* with retries on rate limit (HTTP 429) and abuse errors."""
+    for attempt in range(MAX_RETRIES):
+        try:
+            return fn()
+        except GithubException as exc:
+            if exc.status in (403, 429):
+                wait = RETRY_WAIT * (attempt + 1)
+                print(
+                    f"  Rate limited ({exc.status}) on {label}, "
+                    f"waiting {wait}s (attempt {attempt + 1}/{MAX_RETRIES})",
+                    file=sys.stderr,
+                )
+                time.sleep(wait)
+            else:
+                raise
+    raise RuntimeError(f"Exceeded {MAX_RETRIES} retries for {label}")
+
+
 def results(search_results):
+    seen_repos = set()
     for result in search_results:
         if result.name != "pyproject.toml":
             continue
+
+        repo_full_name = result.repository.full_name
+        if repo_full_name in seen_repos:
+            continue
+        seen_repos.add(repo_full_name)
+
         if result.repository.fork:
             continue
+
         try:
-            toml = tomllib.loads(result.decoded_content.decode())
+            content = _fetch_with_retry(
+                lambda r=result: r.decoded_content.decode(),
+                label=repo_full_name,
+            )
+            toml = tomllib.loads(content)
         except tomllib.TOMLDecodeError:
-            print(f"! Couldn't decode {result.repository.full_name}", file=sys.stderr)
+            print(f"! Couldn't decode {repo_full_name}", file=sys.stderr)
             continue
+        except RuntimeError as exc:
+            print(f"! Skipping {repo_full_name}: {exc}", file=sys.stderr)
+            continue
+
         plugin = {
             "name": result.repository.name,
             "stars": result.repository.stargazers_count,
@@ -36,7 +77,11 @@ def results(search_results):
             plugin["name"] = name
         if description := toml.get("project", {}).get("description"):
             plugin["description"] = description
-        print("Processed", result.repository.full_name, file=sys.stderr)
+        print("Processed", repo_full_name, file=sys.stderr)
+
+        # Small delay between results to stay under secondary rate limits
+        time.sleep(1)
+
         yield plugin
 
 

--- a/scripts/plugin_list.py
+++ b/scripts/plugin_list.py
@@ -9,18 +9,11 @@ from github import GithubException
 
 RETRY_WAIT = 60
 MAX_RETRIES = 5
+DELAY_BETWEEN_RESULTS = 2
 
 
-def search_github():
-    gh = github.Github(os.environ.get("GITHUB_TOKEN"), per_page=30)
-    results = gh.search_code('"[project.entry-points.conda]" language:TOML')
-    if results.totalCount:
-        return results
-    raise RuntimeError("Did not find any results")
-
-
-def _fetch_with_retry(fn, label=""):
-    """Call *fn* with retries on rate limit (HTTP 429) and abuse errors."""
+def _api_call(fn, label=""):
+    """Call *fn* with retries on rate limit (HTTP 429/403) errors."""
     for attempt in range(MAX_RETRIES):
         try:
             return fn()
@@ -38,9 +31,35 @@ def _fetch_with_retry(fn, label=""):
     raise RuntimeError(f"Exceeded {MAX_RETRIES} retries for {label}")
 
 
+def search_github():
+    gh = github.Github(os.environ.get("GITHUB_TOKEN"), per_page=30)
+    query = '"[project.entry-points.conda]" language:TOML'
+    results = gh.search_code(query)
+    total = _api_call(lambda: results.totalCount, label="search totalCount")
+    if not total:
+        raise RuntimeError("Did not find any results")
+    print(f"Found {total} results", file=sys.stderr)
+    return results
+
+
+def _get_page_results(search_results):
+    """Yield results one at a time, retrying on rate limit during pagination."""
+    page = 0
+    while True:
+        items = _api_call(
+            lambda p=page: search_results.get_page(p),
+            label=f"search page {page}",
+        )
+        if not items:
+            break
+        yield from items
+        page += 1
+        time.sleep(DELAY_BETWEEN_RESULTS)
+
+
 def results(search_results):
     seen_repos = set()
-    for result in search_results:
+    for result in _get_page_results(search_results):
         if result.name != "pyproject.toml":
             continue
 
@@ -53,7 +72,7 @@ def results(search_results):
             continue
 
         try:
-            content = _fetch_with_retry(
+            content = _api_call(
                 lambda r=result: r.decoded_content.decode(),
                 label=repo_full_name,
             )
@@ -79,8 +98,7 @@ def results(search_results):
             plugin["description"] = description
         print("Processed", repo_full_name, file=sys.stderr)
 
-        # Small delay between results to stay under secondary rate limits
-        time.sleep(1)
+        time.sleep(DELAY_BETWEEN_RESULTS)
 
         yield plugin
 


### PR DESCRIPTION
## Problem

The weekly README render workflow has been failing with HTTP 429 "Too many requests" errors. The `plugin_list.py` script iterates through all code search results, each triggering additional API calls (file content fetch, repository metadata), which exhausts the GitHub secondary rate limit.

See failed run: https://github.com/conda-incubator/conda-plugins/actions/runs/23732706729/job/69129880412

## Changes

- Add `_fetch_with_retry()` helper that catches HTTP 403/429 and backs off with increasing wait times (60s, 120s, 180s, up to 5 retries)
- Deduplicate results by repository to reduce redundant API calls
- Add 1s delay between processing results to stay under secondary rate limits
- Update `actions/checkout` to v6.0.2 and `actions/setup-python` to v6.2.0 (fixes the Node.js 20 deprecation warning)
- Bump Python from 3.12 to 3.13